### PR TITLE
Feature: Add Prometheus Label Support for Counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Metric Injector enables domain-specific counters tied to routing logic or matche
 
 This plugin introduces a middleware that:
 
-- Registers custom Prometheus `Counter` metrics via Caddy’s metrics registry.
+- Registers custom Prometheus `CounterVec` metrics via Caddy’s metrics registry.
 - Supports optional per-counter request matchers using Caddy’s native HTTP matchers.
+- Supports optional per-counter labels with dynamic values from request placeholders.
 - Increments counters only when matcher conditions are satisfied.
 - Treats counters without a `match` block as match-all (incremented for every request).
 - Counter evaluation occurs after the remaining handler chain has completed.
@@ -52,6 +53,7 @@ metric_injector {
     counter {
       name <prometheus-metric-name>
       help <help-text>
+      label <label-name> <placeholder> [<default-value>]
       match {
          <any Caddy HTTP request matcher>
       }
@@ -79,6 +81,10 @@ You must either:
 
 - `name` (required): Prometheus metric name. Must be unique within the configuration and follow Prometheus naming conventions.
 - `help` (optional): Help/description string. A default description is generated if omitted.
+- `label` (optional): Defines a Prometheus label. You can have multiple `label` lines.
+  - `<label-name>`: The name of the label.
+  - `<placeholder>`: A Caddy placeholder to resolve the label's value at runtime (e.g., `{http.request.method}`).
+  - `<default-value>` (optional): A fallback value if the placeholder is empty. Defaults to `-`.
 - `match` (optional): Any Caddy HTTP request matcher (path, method, header, vars, etc.). If omitted, the counter increments for every request.
 
 ### Example
@@ -95,6 +101,7 @@ reporting.example.com:8080 {
     counter {
       name content_security_policy_reports_total
       help "How many CSP reports were received"
+      label origin {http.request.header.origin} "unknown"
       match {
         path /csp/*
       }
@@ -118,6 +125,15 @@ reporting.example.com:8080 {
 }
 ```
 
+> [!Important]
+> **A Note on Cardinality**
+>
+> While labels are a powerful feature, it is important to use them responsibly. Each unique combination of key-value pairs for labels creates a new time series in Prometheus, which can lead to high cardinality.
+>
+> Avoid using labels with unbounded or high-cardinality values, such as user IDs, session IDs, or full request paths if they are not parameterized. High cardinality can significantly increase memory usage and performance overhead on your Prometheus server.
+>
+> It is the user's responsibility to ensure that the configured labels do not lead to an explosion of metric series.
+
 ## Behavior
 
 - Each request is evaluated against all configured counters.
@@ -129,8 +145,7 @@ reporting.example.com:8080 {
 
 ## Current Limitations
 
-- Only Prometheus `Counter` metrics are supported.
-- No label support (no `CounterVec`, `GaugeVec`, etc.).
+- Only Prometheus `CounterVec` metrics are supported (no `Gauge`, `Histogram`, etc.).
 - Counters are incremented solely based on request matchers.
 - Response status codes, response headers, and response body data are not inspected.
 - Within a single `metric_injector` instance, all configured counters are evaluated for each request handled by that instance.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ metric_injector {
     counter {
       name <prometheus-metric-name>
       help <help-text>
-      label <label-name> <placeholder> [<default-value>]
+      label <label-name> <value|placeholder> [<default-value>]
       match {
          <any Caddy HTTP request matcher>
       }
@@ -83,8 +83,8 @@ You must either:
 - `help` (optional): Help/description string. A default description is generated if omitted.
 - `label` (optional): Defines a Prometheus label. You can have multiple `label` lines.
   - `<label-name>`: The name of the label.
-  - `<placeholder>`: A Caddy placeholder to resolve the label's value at runtime (e.g., `{http.request.method}`).
-  - `<default-value>` (optional): A fallback value if the placeholder is empty. Defaults to `-`.
+  - `<value>`: The value for the label. This can be a static string or a dynamic Caddy placeholder (e.g., `{http.request.method}`).
+  - `<default-value>` (optional): A fallback value if a placeholder resolves to an empty string. This is ignored if `<value>` is a static string. Defaults to `-`.
 - `match` (optional): Any Caddy HTTP request matcher (path, method, header, vars, etc.). If omitted, the counter increments for every request.
 
 ### Example
@@ -102,6 +102,7 @@ reporting.example.com:8080 {
       name content_security_policy_reports_total
       help "How many CSP reports were received"
       label origin {http.request.header.origin} "unknown"
+      label source "caddy"
       match {
         path /csp/*
       }

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -55,6 +55,21 @@ func (m *MetricInjector) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 							return d.ArgErr()
 						}
 						cm.Help = d.Val()
+					case "label":
+						args := d.RemainingArgs()
+						if len(args) < 2 {
+							return d.Errf("label requires at least 2 arguments: name and value")
+						}
+						l := new(Label)
+						l.Name = args[0]
+						l.Value = args[1]
+						// Set default value to "-" if not provided
+						if len(args) > 2 {
+							l.Default = args[2]
+						} else {
+							l.Default = "-"
+						}
+						cm.Labels = append(cm.Labels, l)
 					case "match":
 						matcherSet, err := caddyhttp.ParseCaddyfileNestedMatcherSet(d)
 						if err != nil {

--- a/metric_injector.go
+++ b/metric_injector.go
@@ -31,8 +31,9 @@ var metricNameRegex = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
 // MetricInjector is a Caddy HTTP middleware module that defines and
 // increments custom Prometheus counters.
 //
-// The module allows defining one or more counters that are incremented when
-// incoming requests match configured Caddy HTTP request matchers.
+// The module allows defining one or more counters, with optional labels,
+// that are incremented when incoming requests match configured Caddy HTTP
+// request matchers.
 //
 // Each counter may define optional matcher conditions. If the matchers
 // evaluate to true for a request, the corresponding counter is incremented.
@@ -54,6 +55,17 @@ type MetricInjector struct {
 	logger *zap.Logger
 }
 
+type Label struct {
+	// Name is the Prometheus label name.
+	Name string `json:"name,omitempty"`
+
+	// Value is the placeholder to be evaluated for the label's value.
+	Value string `json:"value,omitempty"`
+
+	// Default is the value to be used if the placeholder is empty.
+	Default string `json:"default,omitempty"`
+}
+
 type CounterMetric struct {
 	// Name is the Prometheus metric name. It must be unique within the
 	// module configuration.
@@ -62,6 +74,9 @@ type CounterMetric struct {
 	// Help is the help/description string for the metric. A sensible default
 	// is generated if this is left empty.
 	Help string `json:"help,omitempty"`
+
+	// Labels is the list of labels for the metric.
+	Labels []*Label `json:"labels,omitempty"`
 
 	// MatcherSetsRaw holds the raw matcher configuration parsed from Caddyfile /
 	// JSON. It is exercise only during Provision; the concrete matcher sets are
@@ -72,8 +87,8 @@ type CounterMetric struct {
 	// request. It remains nil when no matchers were configured.
 	matcherSets caddyhttp.MatcherSets
 
-	// counter is the Prometheus Counter instance used at runtime.
-	counter prometheus.Counter
+	// counter is the Prometheus CounterVec instance used at runtime.
+	counter *prometheus.CounterVec
 }
 
 // CaddyModule returns the Caddy module information.
@@ -125,15 +140,17 @@ func (m *MetricInjector) Provision(ctx caddy.Context) error {
 		}
 
 		m.logger.Debug("creating prometheus counter", zap.String("name", cm.Name), zap.String("help", help))
-		counter := prometheus.NewCounter(prometheus.CounterOpts{
+		counter := prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: cm.Name,
 			Help: help,
-		})
+		}, extractLabelNames(cm.Labels))
 
 		if err := ctx.GetMetricsRegistry().Register(counter); err != nil {
 			if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
 				// reuse existing collector
-				counter = are.ExistingCollector.(prometheus.Counter)
+				if counter, ok = are.ExistingCollector.(*prometheus.CounterVec); !ok {
+					return fmt.Errorf("existing collector for %s is not a CounterVec", cm.Name)
+				}
 				m.logger.Info("reusing already registered counter", zap.String("name", cm.Name))
 			} else {
 				m.logger.Error("failed to register counter", zap.String("name", cm.Name), zap.Error(err))
@@ -171,12 +188,22 @@ func isValidMetricName(name string) bool {
 	return metricNameRegex.MatchString(name)
 }
 
+func extractLabelNames(labels []*Label) []string {
+	names := make([]string, len(labels))
+	for i, l := range labels {
+		names[i] = l.Name
+	}
+	return names
+}
+
 // ServeHTTP evaluates each configured counter and increments those whose
 // matchers (if any) are satisfied by the current request. The next handler
 // in the chain is always invoked first, so metric failures do not block the
 // request.
 func (m MetricInjector) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	err := next.ServeHTTP(w, r)
+
+	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 
 	for _, cm := range m.Counters {
 		// If no matchers configured, treat as match-all
@@ -203,8 +230,19 @@ func (m MetricInjector) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 			continue
 		}
 
-		cm.counter.Inc()
-		m.logger.Debug("incremented counter", zap.String("counter", cm.Name))
+		// Evaluate label values using the replacer.
+		// If a label value is empty after replacement, use the default value.
+		labelValues := make(prometheus.Labels)
+		for _, l := range cm.Labels {
+			val := repl.ReplaceAll(l.Value, l.Default)
+			if val == "" {
+				val = l.Default
+			}
+			labelValues[l.Name] = val
+		}
+
+		cm.counter.With(labelValues).Inc()
+		m.logger.Debug("incremented counter", zap.String("counter", cm.Name), zap.Any("labels", labelValues))
 	}
 
 	return err

--- a/metric_injector.go
+++ b/metric_injector.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
@@ -196,6 +197,13 @@ func extractLabelNames(labels []*Label) []string {
 	return names
 }
 
+func hasPlaceholder(s string) bool {
+	// This is a simple heuristic. A more robust implementation might involve
+	// a more sophisticated parser, but for the common case of checking for
+	// Caddy placeholders like {http.request.method}, this is sufficient.
+	return strings.Contains(s, "{") && strings.Contains(s, "}")
+}
+
 // ServeHTTP evaluates each configured counter and increments those whose
 // matchers (if any) are satisfied by the current request. The next handler
 // in the chain is always invoked first, so metric failures do not block the
@@ -230,11 +238,15 @@ func (m MetricInjector) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 			continue
 		}
 
-		// Evaluate label values using the replacer.
-		// If a label value is empty after replacement, use the default value.
+		// Evaluate label values.
 		labelValues := make(prometheus.Labels)
 		for _, l := range cm.Labels {
-			val := repl.ReplaceAll(l.Value, l.Default)
+			var val string
+			if hasPlaceholder(l.Value) {
+				val = repl.ReplaceAll(l.Value, l.Default)
+			} else {
+				val = l.Value
+			}
 			if val == "" {
 				val = l.Default
 			}


### PR DESCRIPTION
Closes #4

#### Summary

This pull request introduces a major enhancement to the `metric_injector` plugin: support for Prometheus labels on counters. This allows for the creation of multi-dimensional metrics, providing deeper insights and more flexible monitoring capabilities. The implementation transitions from `prometheus.Counter` to `prometheus.CounterVec` to enable this functionality.

#### Motivation

The initial version of the plugin was limited to simple, non-dimensional counters. For meaningful observability, it's often necessary to segment metrics by request attributes like HTTP method, status code, or specific headers. This change addresses that limitation by allowing users to define dynamic labels, making the plugin significantly more powerful for real-world use cases.

#### Implementation Details

-   **Core Change**: The metric type has been upgraded from `prometheus.Counter` to `prometheus.CounterVec`.
-   **New Caddyfile Subdirective**: A new `label` subdirective is introduced within the `counter` block. It accepts three arguments: the label name, a value, and an optional default.
-   **Static and Dynamic Label Values**: The label value can be either a **static string** or a **dynamic Caddy placeholder**.
-   **Intelligent Value Resolution**:
    -   If the value is a static string, it is used directly.
    -   If the value contains a Caddy placeholder (e.g., `{http.request.method}`), it is resolved at request time.
    -   The optional default value is only applied if a placeholder resolves to an empty string.
-   **Updated Provisioning**: The provisioning logic now correctly registers `CounterVec` metrics and handles the reuse of existing collectors, ensuring they are of the correct type.
-   **Documentation**: The README.md has been thoroughly updated to document the new feature, including syntax, examples, and an important warning about the responsible use of labels to avoid high cardinality issues.

#### New Caddyfile Syntax

The `counter` block has been extended to support the `label` directive:

```caddyfile
metric_injector {
    counter {
      name <prometheus-metric-name>
      help <help-text>
      label <label-name> <value|placeholder> [<default-value>]
      match {
         <any Caddy HTTP request matcher>
      }
    }
}
```

#### Example

```caddyfile
metric_injector {
  counter {
    name content_security_policy_reports_total
    help "How many CSP reports were received"

    # Add a label for the request method
    label method {http.request.method}

    # Dynamic label for the origin header with a custom default value
    label origin {http.request.header.origin} "unknown"

    # Static label to segment this metric
    label source "caddy"

    match {
      path /csp/*
    }
  }
}
```