### PR TITLE
Feature: Add Prometheus Gauge Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Caddy Metric Injector Plugin
 
-The **Metric Injector** plugin for [Caddy](https://caddyserver.com) provides a minimalistic way to define and increment custom Prometheus counters during HTTP request handling.
+The **Metric Injector** plugin for [Caddy](https://caddyserver.com) provides a minimalistic way to define and process custom Prometheus metrics (counters and gauges) during HTTP request handling.
 
-It allows you to declaratively configure one or more counters and optionally bind them to Caddy request matchers. Each matching request increments the corresponding metric.
+It allows you to declaratively configure one or more counters and gauges, and optionally bind them to Caddy request matchers. Each matching request processes the corresponding metric.
 
-Counters are evaluated after the remaining handler chain has executed, ensuring that metric collection does not interfere with request processing.
+Metrics are evaluated after the remaining handler chain has executed, ensuring that metric collection does not interfere with request processing.
 
 This plugin is intended as a complement to Caddy’s built-in metrics.
-Metric Injector enables domain-specific counters tied to routing logic or matcher conditions that are not covered by the built-in metrics.
+Metric Injector enables domain-specific metrics tied to routing logic or matcher conditions that are not covered by the built-in metrics.
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/steffenbusch/caddy-metric-injector)](https://goreportcard.com/report/github.com/steffenbusch/caddy-metric-injector)
 
@@ -15,13 +15,13 @@ Metric Injector enables domain-specific counters tied to routing logic or matche
 
 This plugin introduces a middleware that:
 
-- Registers custom Prometheus `CounterVec` metrics via Caddy’s metrics registry.
-- Supports optional per-counter request matchers using Caddy’s native HTTP matchers.
-- Supports optional per-counter labels with dynamic values from request placeholders.
-- Increments counters only when matcher conditions are satisfied.
-- Treats counters without a `match` block as match-all (incremented for every request).
-- Counter evaluation occurs after the remaining handler chain has completed.
-- Validates configuration at provisioning time (e.g. duplicate counter name detection).
+- Registers custom Prometheus `CounterVec` and `GaugeVec` metrics via Caddy’s metrics registry.
+- Supports optional per-metric request matchers using Caddy’s native HTTP matchers.
+- Supports optional per-metric labels with dynamic values from request placeholders.
+- Processes metrics only when matcher conditions are satisfied.
+- Treats metrics without a `match` block as match-all (processed for every request).
+- Metric evaluation occurs after the remaining handler chain has completed.
+- Validates configuration at provisioning time (e.g. duplicate metric name detection).
 
 ## Installation
 
@@ -33,7 +33,7 @@ xcaddy build --with github.com/steffenbusch/caddy-metric-injector
 
 ## Caddyfile
 
-Use one or more `counter` blocks inside `metric_injector`.
+Use one or more `counter` or `gauge` blocks inside `metric_injector`.
 
 ### Enabling Metrics
 
@@ -58,6 +58,16 @@ metric_injector {
          <any Caddy HTTP request matcher>
       }
     }
+
+    gauge {
+      name <prometheus-metric-name>
+      help <help-text>
+      value <value|placeholder>
+      label <label-name> <value|placeholder> [<default-value>]
+      match {
+         <any Caddy HTTP request matcher>
+      }
+    }
 }
 ```
 
@@ -77,7 +87,9 @@ You must either:
 
 - Or use it inside an explicit `route` block to control execution order.
 
-### Counter block fields
+### Block Fields
+
+The following fields are common to both `counter` and `gauge` blocks:
 
 - `name` (required): Prometheus metric name. Must be unique within the configuration and follow Prometheus naming conventions.
 - `help` (optional): Help/description string. A default description is generated if omitted.
@@ -85,7 +97,11 @@ You must either:
   - `<label-name>`: The name of the label.
   - `<value>`: The value for the label. This can be a static string or a dynamic Caddy placeholder (e.g., `{http.request.method}`).
   - `<default-value>` (optional): A fallback value if a placeholder resolves to an empty string. This is ignored if `<value>` is a static string. Defaults to `-`.
-- `match` (optional): Any Caddy HTTP request matcher (path, method, header, vars, etc.). If omitted, the counter increments for every request.
+- `match` (optional): Any Caddy HTTP request matcher (path, method, header, vars, etc.). If omitted, the metric is processed for every request.
+
+#### `gauge` specific fields
+
+- `value` (required): The value to set the gauge to. This can be a static number or a Caddy placeholder that resolves to a number.
 
 ### Example
 
@@ -98,8 +114,9 @@ You must either:
 reporting.example.com:8080 {
 
   metric_injector {
+    # Increment a counter for every CSP report
     counter {
-      name content_security_policy_reports_total
+      name csp_reports_total
       help "How many CSP reports were received"
       label origin {http.request.header.origin} "unknown"
       label source "caddy"
@@ -107,6 +124,17 @@ reporting.example.com:8080 {
         path /csp/*
       }
     }
+
+    # Set a gauge to the current timestamp for every CSP report
+    gauge {
+        name csp_last_report_timestamp_seconds
+        help "Unix timestamp when the last CSP report was received"
+        value {time.now.unix}
+        match {
+            path /csp/*
+        }
+    }
+
     counter {
       name network_error_reporting_reports_total
       help "How many NEL reports were received"
@@ -137,22 +165,22 @@ reporting.example.com:8080 {
 
 ## Behavior
 
-- Each request is evaluated against all configured counters.
-- Counters without a `match` block increment for every request.
-- Counter evaluation occurs after the remaining handler chain has executed.
-- Counters are incremented synchronously during request handling.
+- Each request is evaluated against all configured metrics (counters and gauges).
+- Metrics without a `match` block are processed for every request.
+- Metric evaluation occurs after the remaining handler chain has executed.
+- Metrics are processed synchronously during request handling.
 - The request and response flow are not modified by this middleware.
-- Matcher evaluation errors are logged and only affect the respective counter; requests are never blocked.
+- Matcher evaluation errors are logged and only affect the respective metric; requests are never blocked.
 
 ## Current Limitations
 
-- Only Prometheus `CounterVec` metrics are supported (no `Gauge`, `Histogram`, etc.).
-- Counters are incremented solely based on request matchers.
+- Only Prometheus `CounterVec` and `GaugeVec` metrics are supported (no `Histogram`, etc.).
+- Metrics are processed solely based on request matchers.
 - Response status codes, response headers, and response body data are not inspected.
-- Within a single `metric_injector` instance, all configured counters are evaluated for each request handled by that instance.
-- Counter values are process-local and reset on Caddy reload or restart.
+- Within a single `metric_injector` instance, all configured metrics are evaluated for each request handled by that instance.
+- Metric values are process-local and reset on Caddy reload or restart.
 
-This module intentionally focuses on simple, declarative counters.
+This module intentionally focuses on simple, declarative counters and gauges.
 
 ## License
 

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -36,6 +36,24 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 	return m, nil
 }
 
+// parseMetricLabel parses a label directive from the Caddyfile
+func parseMetricLabel(d *caddyfile.Dispenser) (*Label, error) {
+	args := d.RemainingArgs()
+	if len(args) < 2 {
+		return nil, d.Errf("label requires at least 2 arguments: name and value")
+	}
+	l := new(Label)
+	l.Name = args[0]
+	l.Value = args[1]
+	// Set default value to "-" if not provided
+	if len(args) > 2 {
+		l.Default = args[2]
+	} else {
+		l.Default = "-"
+	}
+	return l, nil
+}
+
 // UnmarshalCaddyfile parses the metric_injector block from the Caddyfile
 func (m *MetricInjector) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
@@ -56,18 +74,9 @@ func (m *MetricInjector) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 						}
 						cm.Help = d.Val()
 					case "label":
-						args := d.RemainingArgs()
-						if len(args) < 2 {
-							return d.Errf("label requires at least 2 arguments: name and value")
-						}
-						l := new(Label)
-						l.Name = args[0]
-						l.Value = args[1]
-						// Set default value to "-" if not provided
-						if len(args) > 2 {
-							l.Default = args[2]
-						} else {
-							l.Default = "-"
+						l, err := parseMetricLabel(d)
+						if err != nil {
+							return err
 						}
 						cm.Labels = append(cm.Labels, l)
 					case "match":
@@ -81,6 +90,42 @@ func (m *MetricInjector) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					}
 				}
 				m.Counters = append(m.Counters, cm)
+			case "gauge":
+				gm := new(GaugeMetric)
+				for d.NextBlock(1) {
+					switch d.Val() {
+					case "name":
+						if !d.NextArg() {
+							return d.ArgErr()
+						}
+						gm.Name = d.Val()
+					case "help":
+						if !d.NextArg() {
+							return d.ArgErr()
+						}
+						gm.Help = d.Val()
+					case "value":
+						if !d.NextArg() {
+							return d.ArgErr()
+						}
+						gm.Value = d.Val()
+					case "label":
+						l, err := parseMetricLabel(d)
+						if err != nil {
+							return err
+						}
+						gm.Labels = append(gm.Labels, l)
+					case "match":
+						matcherSet, err := caddyhttp.ParseCaddyfileNestedMatcherSet(d)
+						if err != nil {
+							return err
+						}
+						gm.MatcherSetsRaw = append(gm.MatcherSetsRaw, matcherSet)
+					default:
+						return d.Errf("unknown directive: %s", d.Val())
+					}
+				}
+				m.Gauges = append(m.Gauges, gm)
 			default:
 				return d.Errf("unknown directive: %s", d.Val())
 			}

--- a/metric_injector.go
+++ b/metric_injector.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/caddyserver/caddy/v2"
@@ -48,8 +49,11 @@ var metricNameRegex = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
 // through the standard Prometheus metrics endpoint when the global `metrics`
 // option is enabled.
 type MetricInjector struct {
-	// Counters is the list of metrics that should be tracked.
+	// Counters is the list of counter metrics that should be tracked.
 	Counters []*CounterMetric `json:"counters,omitempty"`
+
+	// Gauges is the list of gauge metrics that should be tracked.
+	Gauges []*GaugeMetric `json:"gauges,omitempty"`
 
 	// logger provides structured logging for the module.
 	// It's initialized in the Provision method and used throughout the module for debug information.
@@ -65,6 +69,34 @@ type Label struct {
 
 	// Default is the value to be used if the placeholder is empty.
 	Default string `json:"default,omitempty"`
+}
+
+type GaugeMetric struct {
+	// Name is the Prometheus metric name. It must be unique within the
+	// module configuration.
+	Name string `json:"name,omitempty"`
+
+	// Help is the help/description string for the metric. A sensible default
+	// is generated if this is left empty.
+	Help string `json:"help,omitempty"`
+
+	// Value is the placeholder for the value to be set.
+	Value string `json:"value,omitempty"`
+
+	// Labels is the list of labels for the metric.
+	Labels []*Label `json:"labels,omitempty"`
+
+	// MatcherSetsRaw holds the raw matcher configuration parsed from Caddyfile /
+	// JSON. It is exercise only during Provision; the concrete matcher sets are
+	// produced from it and stored in matcherSets.
+	MatcherSetsRaw caddyhttp.RawMatcherSets `json:"match,omitempty" caddy:"namespace=http.matchers"`
+
+	// matcherSets contains the compiled matcher sets that are evaluated for each
+	// request. It remains nil when no matchers were configured.
+	matcherSets caddyhttp.MatcherSets
+
+	// gauge is the Prometheus GaugeVec instance used at runtime.
+	gauge *prometheus.GaugeVec
 }
 
 type CounterMetric struct {
@@ -108,12 +140,12 @@ func (MetricInjector) CaddyModule() caddy.ModuleInfo {
 func (m *MetricInjector) Provision(ctx caddy.Context) error {
 	m.logger = ctx.Logger(m)
 
-	if len(m.Counters) == 0 {
-		m.logger.Error("no counters configured")
-		return fmt.Errorf("at least one counter must be defined")
+	if len(m.Counters) == 0 && len(m.Gauges) == 0 {
+		m.logger.Error("no counters or gauges configured")
+		return fmt.Errorf("at least one counter or gauge must be defined")
 	}
 
-	m.logger.Info("Provisioning MetricInjector", zap.Int("configured_counters", len(m.Counters)))
+	m.logger.Info("Provisioning MetricInjector", zap.Int("configured_counters", len(m.Counters)), zap.Int("configured_gauges", len(m.Gauges)))
 
 	nameSet := make(map[string]struct{})
 
@@ -181,7 +213,71 @@ func (m *MetricInjector) Provision(ctx caddy.Context) error {
 		}
 	}
 
-	m.logger.Info("MetricInjector provisioned", zap.Int("active_counters", len(m.Counters)))
+	for _, gm := range m.Gauges {
+		if gm.Name == "" {
+			m.logger.Error("gauge name missing", zap.Any("gauge_def", gm))
+			return errors.New("gauge: name is required")
+		}
+
+		if _, exists := nameSet[gm.Name]; exists {
+			m.logger.Error("duplicate gauge name detected", zap.String("name", gm.Name))
+			return fmt.Errorf("duplicate gauge name: %s", gm.Name)
+		}
+
+		if !isValidMetricName(gm.Name) {
+			m.logger.Error("invalid prometheus metric name", zap.String("name", gm.Name))
+			return fmt.Errorf("invalid Prometheus metric name: %s", gm.Name)
+		}
+
+		nameSet[gm.Name] = struct{}{}
+
+		help := gm.Help
+		if help == "" {
+			help = fmt.Sprintf("Gauge for %s", gm.Name)
+		}
+
+		m.logger.Debug("creating prometheus gauge", zap.String("name", gm.Name), zap.String("help", help))
+		gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: gm.Name,
+			Help: help,
+		}, extractLabelNames(gm.Labels))
+
+		if err := ctx.GetMetricsRegistry().Register(gauge); err != nil {
+			if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+				// reuse existing collector
+				if gauge, ok = are.ExistingCollector.(*prometheus.GaugeVec); !ok {
+					return fmt.Errorf("existing collector for %s is not a GaugeVec", gm.Name)
+				}
+				m.logger.Info("reusing already registered gauge", zap.String("name", gm.Name))
+			} else {
+				m.logger.Error("failed to register gauge", zap.String("name", gm.Name), zap.Error(err))
+				return err
+			}
+		} else {
+			m.logger.Info("registered gauge with Caddy metrics registry", zap.String("name", gm.Name))
+		}
+
+		gm.gauge = gauge
+
+		if len(gm.MatcherSetsRaw) > 0 {
+			m.logger.Debug("loading matcher sets for gauge", zap.String("name", gm.Name))
+			matcherSets, err := ctx.LoadModule(gm, "MatcherSetsRaw")
+			if err != nil {
+				m.logger.Error("failed to load matcher sets", zap.String("name", gm.Name), zap.Error(err))
+				return err
+			}
+			err = gm.matcherSets.FromInterface(matcherSets)
+			if err != nil {
+				m.logger.Error("failed to parse matcher sets", zap.String("name", gm.Name), zap.Error(err))
+				return err
+			}
+			m.logger.Debug("matcher sets loaded", zap.String("name", gm.Name), zap.Int("matchers", len(gm.matcherSets)))
+		} else {
+			m.logger.Debug("no matcher sets configured for gauge", zap.String("name", gm.Name))
+		}
+	}
+
+	m.logger.Info("MetricInjector provisioned", zap.Int("active_counters", len(m.Counters)), zap.Int("active_gauges", len(m.Gauges)))
 	return nil
 }
 
@@ -255,6 +351,64 @@ func (m MetricInjector) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 
 		cm.counter.With(labelValues).Inc()
 		m.logger.Debug("incremented counter", zap.String("counter", cm.Name), zap.Any("labels", labelValues))
+	}
+
+	for _, gm := range m.Gauges {
+		// If no matchers configured, treat as match-all
+		var matches bool
+		var matchErr error
+
+		if len(gm.matcherSets) == 0 {
+			matches = true
+		} else {
+			matches, matchErr = gm.matcherSets.AnyMatchWithError(r)
+			if matchErr != nil {
+				m.logger.Warn("matcher evaluation error", zap.String("gauge", gm.Name), zap.Error(matchErr))
+				continue
+			}
+		}
+
+		if !matches {
+			m.logger.Debug("request did not match gauge's matchers", zap.String("gauge", gm.Name))
+			continue
+		}
+
+		if gm.gauge == nil {
+			m.logger.Warn("gauge instance is nil, skipping set", zap.String("gauge", gm.Name))
+			continue
+		}
+
+		// Evaluate label values.
+		labelValues := make(prometheus.Labels)
+		for _, l := range gm.Labels {
+			var val string
+			if hasPlaceholder(l.Value) {
+				val = repl.ReplaceAll(l.Value, l.Default)
+			} else {
+				val = l.Value
+			}
+			if val == "" {
+				val = l.Default
+			}
+			labelValues[l.Name] = val
+		}
+
+		// Set the gauge value. If the value placeholder is empty, use the default.
+		var gaugeValue float64
+		if gm.Value == "" {
+			gaugeValue = 0
+		} else {
+			valStr := repl.ReplaceAll(gm.Value, "0")
+			parsedValue, err := strconv.ParseFloat(valStr, 64)
+			if err != nil {
+				m.logger.Warn("failed to parse gauge value", zap.String("gauge", gm.Name), zap.String("value", gm.Value), zap.Error(err))
+				continue
+			}
+			gaugeValue = parsedValue
+		}
+
+		gm.gauge.With(labelValues).Set(gaugeValue)
+		m.logger.Debug("set gauge", zap.String("gauge", gm.Name), zap.Any("labels", labelValues), zap.Float64("value", gaugeValue))
 	}
 
 	return err


### PR DESCRIPTION
Closes #6

#### Summary

This pull request significantly expands the plugin's capabilities by introducing support for Prometheus `Gauge` metrics, in addition to the existing `Counter` metrics. This allows users to set arbitrary numeric values based on request data, perfect for tracking things like timestamps, sizes, or durations.

This PR builds directly on the label support added previously, making both counters and gauges fully dimensional.

#### Motivation

While counters are excellent for incrementing events, they cannot capture values that can arbitrarily go up and down. Gauges are a fundamental metric type for monitoring values like the timestamp of the last event, the size of a request, or the number of active connections. Adding gauge support makes the `metric_injector` a more complete and versatile tool for creating custom metrics.

#### Implementation Details

-   **New Metric Type**: `GaugeMetric` struct and associated logic have been added to support `prometheus.GaugeVec`.
-   **New Caddyfile Directive**: A new top-level `gauge` block is introduced in the `metric_injector` directive.
-   **Value Directive**: The `gauge` block includes a required `value` subdirective, which accepts a static number or a Caddy placeholder that resolves to a numeric value.
-   **Robust Value Parsing**: The `ServeHTTP` logic safely parses the resolved gauge value into a `float64`. If parsing fails (e.g., the placeholder resolves to a non-numeric string), a warning is logged, and the metric is skipped for that request, preventing crashes.
-   **Shared Label Logic**: The label parsing and handling logic has been refactored into a shared helper function (`parseMetricLabel`) to keep the code DRY and maintainable.
-   **Comprehensive Documentation**: The README.md has been updated to cover the new `gauge` directive, including its syntax, a dedicated example, and clearer field descriptions for both metric types.

#### New Caddyfile Syntax

The `metric_injector` now supports both `counter` and `gauge` blocks:

```caddyfile
metric_injector {
    counter {
      name <prometheus-metric-name>
      # ... counter fields
    }

    gauge {
      name <prometheus-metric-name>
      help <help-text>
      value <value|placeholder>
      label <label-name> <value|placeholder> [<default-value>]
      match {
         <any Caddy HTTP request matcher>
      }
    }
}
```

#### Example

```caddyfile
metric_injector {
  # Increment a counter for every CSP report
  counter {
    name csp_reports_total
    help "How many CSP reports were received"
    label origin {http.request.header.origin} "unknown"
    match {
      path /csp/*
    }
  }

  # Set a gauge to the current timestamp for every CSP report
  gauge {
    name csp_last_report_timestamp_seconds
    help "Unix timestamp when the last CSP report was received"
    value {time.now.unix}
    match {
        path /csp/*
    }
  }
}
```